### PR TITLE
Move models and system extensions to separate files.

### DIFF
--- a/Scrapbook.xcodeproj/project.pbxproj
+++ b/Scrapbook.xcodeproj/project.pbxproj
@@ -13,6 +13,13 @@
 		393AA10D24A93CBF00AAE3EC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 393AA10C24A93CBF00AAE3EC /* Assets.xcassets */; };
 		393AA11024A93CBF00AAE3EC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 393AA10F24A93CBF00AAE3EC /* Preview Assets.xcassets */; };
 		393AA11324A93CBF00AAE3EC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 393AA11124A93CBF00AAE3EC /* LaunchScreen.storyboard */; };
+		5947543624ACD6BD00808745 /* Date+TimeBefore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5947543524ACD6BD00808745 /* Date+TimeBefore.swift */; };
+		5947543824ACD6E700808745 /* Date+scrapbookFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5947543724ACD6E700808745 /* Date+scrapbookFormat.swift */; };
+		5947543A24ACD7BE00808745 /* Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5947543924ACD7BE00808745 /* Thumbnail.swift */; };
+		5947543C24ACD7C600808745 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5947543B24ACD7C600808745 /* Post.swift */; };
+		5947543E24ACD7CD00808745 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5947543D24ACD7CD00808745 /* User.swift */; };
+		5947544024ACD82A00808745 /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5947543F24ACD82A00808745 /* Attachment.swift */; };
+		5947544224ACDE4200808745 /* ScrapbookDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5947544124ACDE4200808745 /* ScrapbookDataService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +31,13 @@
 		393AA10F24A93CBF00AAE3EC /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		393AA11224A93CBF00AAE3EC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		393AA11424A93CBF00AAE3EC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5947543524ACD6BD00808745 /* Date+TimeBefore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TimeBefore.swift"; sourceTree = "<group>"; };
+		5947543724ACD6E700808745 /* Date+scrapbookFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+scrapbookFormat.swift"; sourceTree = "<group>"; };
+		5947543924ACD7BE00808745 /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
+		5947543B24ACD7C600808745 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
+		5947543D24ACD7CD00808745 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		5947543F24ACD82A00808745 /* Attachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attachment.swift; sourceTree = "<group>"; };
+		5947544124ACDE4200808745 /* ScrapbookDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapbookDataService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +70,8 @@
 		393AA10524A93CBD00AAE3EC /* Scrapbook */ = {
 			isa = PBXGroup;
 			children = (
+				5947543424ACD69900808745 /* System Extensions */,
+				5947543324ACD69100808745 /* Models */,
 				393AA10624A93CBD00AAE3EC /* AppDelegate.swift */,
 				393AA10824A93CBD00AAE3EC /* SceneDelegate.swift */,
 				393AA10A24A93CBD00AAE3EC /* ContentView.swift */,
@@ -73,6 +89,27 @@
 				393AA10F24A93CBF00AAE3EC /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		5947543324ACD69100808745 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5947543924ACD7BE00808745 /* Thumbnail.swift */,
+				5947543B24ACD7C600808745 /* Post.swift */,
+				5947543D24ACD7CD00808745 /* User.swift */,
+				5947543F24ACD82A00808745 /* Attachment.swift */,
+				5947544124ACDE4200808745 /* ScrapbookDataService.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		5947543424ACD69900808745 /* System Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				5947543524ACD6BD00808745 /* Date+TimeBefore.swift */,
+				5947543724ACD6E700808745 /* Date+scrapbookFormat.swift */,
+			);
+			path = "System Extensions";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -147,8 +184,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				393AA10724A93CBD00AAE3EC /* AppDelegate.swift in Sources */,
+				5947544024ACD82A00808745 /* Attachment.swift in Sources */,
 				393AA10924A93CBD00AAE3EC /* SceneDelegate.swift in Sources */,
+				5947543A24ACD7BE00808745 /* Thumbnail.swift in Sources */,
 				393AA10B24A93CBD00AAE3EC /* ContentView.swift in Sources */,
+				5947543E24ACD7CD00808745 /* User.swift in Sources */,
+				5947544224ACDE4200808745 /* ScrapbookDataService.swift in Sources */,
+				5947543824ACD6E700808745 /* Date+scrapbookFormat.swift in Sources */,
+				5947543C24ACD7C600808745 /* Post.swift in Sources */,
+				5947543624ACD6BD00808745 /* Date+TimeBefore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Scrapbook/Models/Attachment.swift
+++ b/Scrapbook/Models/Attachment.swift
@@ -1,0 +1,22 @@
+//
+//  Attachment.swift
+//  Scrapbook
+//
+//  Created by Nathan Lawrence on 7/1/20.
+//  Copyright © 2020 Lachlan Campbell. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+struct Attachment: Codable, Identifiable {
+    public var id: String
+    public var url: String
+    public var type: String
+    public var filename: String
+    public var thumbnails: ThumbnailCollection?
+    public var largeUrl: URL? {
+        guard let urlString = thumbnails?.large?.url else { return nil }
+        return URL(string: urlString)
+    }
+}

--- a/Scrapbook/Models/Post.swift
+++ b/Scrapbook/Models/Post.swift
@@ -1,0 +1,22 @@
+//
+//  Post.swift
+//  Scrapbook
+//
+//  Created by Nathan Lawrence on 7/1/20.
+//  Copyright © 2020 Lachlan Campbell. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+struct Post: Codable, Identifiable {
+    public var id: String
+    public var user: User
+    public var text: String
+    public var attachments: Array<Attachment>
+
+    public var timestamp: String?
+    public var timestampDate: Date? {
+        return Date(timeIntervalSince1970: Double(self.timestamp ?? "0") ?? 0)
+    }
+}

--- a/Scrapbook/Models/ScrapbookDataService.swift
+++ b/Scrapbook/Models/ScrapbookDataService.swift
@@ -1,0 +1,34 @@
+//
+//  ScrapbookDataService.swift
+//  Scrapbook
+//
+//  Created by Nathan Lawrence on 7/1/20.
+//  Copyright © 2020 Lachlan Campbell. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class ScrapbookDataService: ObservableObject {
+    @Published var posts = [Post]()
+
+    init() {
+        let url = URL(string: "https://scrapbook.hackclub.com/api/posts/")!
+        URLSession.shared.dataTask(with: url) { (data, res, error) in
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .secondsSince1970
+            do {
+                if let postsData = data {
+                    let decodedData = try decoder.decode([Post].self, from: postsData)
+                    DispatchQueue.main.async {
+                        self.posts = decodedData
+                    }
+                } else {
+                    print("No data")
+                }
+            } catch {
+                print("Error \(error)")
+            }
+        }.resume()
+    }
+}

--- a/Scrapbook/Models/Thumbnail.swift
+++ b/Scrapbook/Models/Thumbnail.swift
@@ -1,0 +1,28 @@
+//
+//  Thumbnail.swift
+//  Scrapbook
+//
+//  Created by Nathan Lawrence on 7/1/20.
+//  Copyright © 2020 Lachlan Campbell. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+struct Thumbnail: Codable, Identifiable {
+    public var id: String {
+        return url
+    }
+    public var url: String
+    public var width: Int
+    public var height: Int
+}
+
+struct ThumbnailCollection: Codable, Identifiable {
+    public var id: String {
+        return "thumbnails-\(full?.url ?? UUID().uuidString)"
+    }
+    public var small: Thumbnail?
+    public var large: Thumbnail?
+    public var full: Thumbnail?
+}

--- a/Scrapbook/Models/User.swift
+++ b/Scrapbook/Models/User.swift
@@ -1,0 +1,26 @@
+//
+//  User.swift
+//  Scrapbook
+//
+//  Created by Nathan Lawrence on 7/1/20.
+//  Copyright © 2020 Lachlan Campbell. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+struct User: Codable, Identifiable {
+    public var id: String
+    public var username: String
+    public var streakCount: Int
+    // css, slack, github, website
+
+    public var avatar: String?
+    public var avatarUrl: URL {
+        guard let urlString = avatar,
+              let urlParsed = URL(string: urlString) else {
+            return URL(string: "https://hackclub.com/team/orpheus.jpg")!
+        }
+        return urlParsed
+    }
+}

--- a/Scrapbook/System Extensions/Date+TimeBefore.swift
+++ b/Scrapbook/System Extensions/Date+TimeBefore.swift
@@ -1,0 +1,51 @@
+//
+//  Date+TimeBefore.swift
+//  Scrapbook
+//
+//  Created by Nathan Lawrence on 7/1/20.
+//  Copyright © 2020 Lachlan Campbell. All rights reserved.
+//
+
+import Foundation
+
+extension Date {
+
+    func isBefore(date : Date) -> Bool {
+        return self < date
+    }
+
+    func isAfter(date : Date) -> Bool {
+        return self > date
+    }
+
+    var secondsAgo : Double {
+        get {
+            return -(self.timeIntervalSinceNow)
+        }
+    }
+
+    var minutesAgo : Double {
+        get {
+            return (self.secondsAgo / 60)
+        }
+    }
+
+    var hoursAgo : Double {
+        get {
+            return (self.minutesAgo / 60)
+        }
+    }
+
+    var daysAgo : Double {
+        get {
+            return (self.hoursAgo / 24)
+        }
+    }
+
+    var weeksAgo : Double {
+        get {
+            return (self.daysAgo / 7)
+        }
+    }
+
+}

--- a/Scrapbook/System Extensions/Date+scrapbookFormat.swift
+++ b/Scrapbook/System Extensions/Date+scrapbookFormat.swift
@@ -1,0 +1,32 @@
+//
+//  Date+scrapbookFormat.swift
+//  Scrapbook
+//
+//  Created by Nathan Lawrence on 7/1/20.
+//  Copyright © 2020 Lachlan Campbell. All rights reserved.
+//
+
+import Foundation
+
+extension Date {
+
+    /**
+     Date format for use on the Scrapbook timeline. Relative when the date is in the last 24 hours, absolute otherwise.
+     */
+    var scrapbookFormat: String {
+        return Date.scrapbookFormatDate(self)
+    }
+
+    fileprivate static func scrapbookFormatDate(_ dt: Date) -> String {
+        if dt.hoursAgo >= 24 {
+            let absoluteFormatter = DateFormatter()
+            absoluteFormatter.dateFormat = "MMM d"
+            return absoluteFormatter.string(from: Date().addingTimeInterval(-1000000))
+        } else {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .short
+            return formatter.localizedString(for: dt, relativeTo: Date())
+        }
+    }
+
+}


### PR DESCRIPTION
This PR would move models and system extensions to separate files, as well as refactoring the Scrapbook date formatter out of the global namespace and into an extension on `Date`. It also renames the class `FetchPosts` to the more conventional `ScrapbookDataService`.